### PR TITLE
Implement Sync for LateStatic<T> only if T is Sync too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub struct LateStatic<T> {
 }
 
 unsafe impl<T: Send> core::marker::Send for LateStatic<T> {}
-unsafe impl<T: Send> core::marker::Sync for LateStatic<T> {}
+unsafe impl<T: Sync> core::marker::Sync for LateStatic<T> {}
 
 impl<T> LateStatic<T> {
     /// Construct a LateStatic.


### PR DESCRIPTION
This fixes what is most likely a typo. `LateStatic<T>` should implement `Sync` only if `T` is `Sync` too.

Closes: #1 